### PR TITLE
Pull and publish .csv versions of databases

### DIFF
--- a/.github/workflows/GeoLite.yml
+++ b/.github/workflows/GeoLite.yml
@@ -31,6 +31,22 @@ jobs:
         cp -v GeoLite*/*.mmdb upload
         echo "TAG_NAME=$(date +"%Y.%m.%d")" >> $GITHUB_ENV
 
+    - name: Download GeoLite.csv
+      run: |
+        wget -nv -O GeoLite2-ASN-CSV.zip "https://download.maxmind.com/app/geoip_download_by_token?edition_id=GeoLite2-ASN-CSV&license_key=${{ secrets.LICENSE_KEY }}&suffix=zip"
+        wget -nv -O GeoLite2-Country-CSV.zip "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&license_key=${{ secrets.LICENSE_KEY }}&suffix=zip"
+        wget -nv -O GeoLite2-City-CSV.zip "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City-CSV&license_key=${{ secrets.LICENSE_KEY }}&suffix=zip"
+    
+    - name: Decompress Zips
+      uses: TonyBogdanov/zip@1.0
+      with:
+          args: unzip -qq GeoLite2-*-CSV.zip
+
+    - name: Copy GeoLite2.csv
+      run: |
+        cp -v GeoLite*/*.csv upload
+        echo "TAG_NAME=$(date +"%Y.%m.%d")" >> $GITHUB_ENV
+
     - name: Push to "download" branch
       run: |
         cd upload
@@ -50,7 +66,9 @@ jobs:
       with:
         tag_name: ${{ env.TAG_NAME }}
         body: ${{ env.TAG_NAME }}
-        files: upload/*.mmdb
+        files: |
+          upload/*.mmdb
+          upload/*.csv
 
     - name: Remove old Releases
       uses: dev-drprasad/delete-older-releases@v0.2.0

--- a/.github/workflows/GeoLite.yml
+++ b/.github/workflows/GeoLite.yml
@@ -45,9 +45,9 @@ jobs:
     - name: Copy GeoLite2.csv
       run: |
         cp -v GeoLite*/*.csv upload
-        split -l 650000 -d upload/GeoLite2-City-Blocks-IPv4.csv upload/GeoLite2-City-Blocks-IPv4.csv.
+        split -l 650000 -d --additional-suffix .csv upload/GeoLite2-City-Blocks-IPv4.csv upload/GeoLite2-City-Blocks-IPv4.csv.
         rm upload/GeoLite2-City-Blocks-IPv4.csv
-        split -l 650000 -d upload/GeoLite2-City-Blocks-IPv6.csv upload/GeoLite2-City-Blocks-IPv6.csv.
+        split -l 650000 -d --additional-suffix .csv upload/GeoLite2-City-Blocks-IPv6.csv upload/GeoLite2-City-Blocks-IPv6.csv.
         rm upload/GeoLite2-City-Blocks-IPv6.csv
         echo "TAG_NAME=$(date +"%Y.%m.%d")" >> $GITHUB_ENV
 

--- a/.github/workflows/GeoLite.yml
+++ b/.github/workflows/GeoLite.yml
@@ -45,6 +45,10 @@ jobs:
     - name: Copy GeoLite2.csv
       run: |
         cp -v GeoLite*/*.csv upload
+        split -l 650000 -d upload/GeoLite2-City-Blocks-IPv4.csv upload/GeoLite2-City-Blocks-IPv4.csv.
+        rm upload/GeoLite2-City-Blocks-IPv4.csv
+        split -l 650000 -d upload/GeoLite2-City-Blocks-IPv6.csv upload/GeoLite2-City-Blocks-IPv6.csv.
+        rm upload/GeoLite2-City-Blocks-IPv6.csv
         echo "TAG_NAME=$(date +"%Y.%m.%d")" >> $GITHUB_ENV
 
     - name: Push to "download" branch


### PR DESCRIPTION
For some use cases it is desirable to be able to pull the .csv versions of the databases from a branch. Another project exists which publishes them as releases, but these are not necessarily well referenceable. I added to the workflow to pull and publish the .cs versions just like the .mmdb versions in "downloads" and as release. Two of the files have to be split, as they would otherwise breach the 100mb limitation of Github.